### PR TITLE
Fix: add missing readme.md for g++ and clang++ GLUT samples

### DIFF
--- a/native_linux/clang++/opengl1.0_glut/triangle/readme.md
+++ b/native_linux/clang++/opengl1.0_glut/triangle/readme.md
@@ -1,0 +1,6 @@
+## How to build
+
+```sh
+clang++ -o hello hello.cpp -lGL -lglut
+./hello
+```

--- a/native_linux/clang++/opengl1.1_glut/triangle/readme.md
+++ b/native_linux/clang++/opengl1.1_glut/triangle/readme.md
@@ -1,0 +1,6 @@
+## How to build
+
+```sh
+clang++ -o hello hello.cpp -lGL -lglut
+./hello
+```

--- a/native_linux/clang++/opengl2.0_glut/triangle/readme.md
+++ b/native_linux/clang++/opengl2.0_glut/triangle/readme.md
@@ -1,0 +1,6 @@
+## How to build
+
+```sh
+clang++ -o hello hello.cpp -lGL -lglut
+./hello
+```

--- a/native_linux/clang++/opengl3.3_glut/triangle/readme.md
+++ b/native_linux/clang++/opengl3.3_glut/triangle/readme.md
@@ -1,0 +1,6 @@
+## How to build
+
+```sh
+clang++ -o hello hello.cpp -lGL -lglut
+./hello
+```

--- a/native_linux/clang++/opengl4.5_glut/triangle/readme.md
+++ b/native_linux/clang++/opengl4.5_glut/triangle/readme.md
@@ -1,0 +1,6 @@
+## How to build
+
+```sh
+clang++ -o hello hello.cpp -lGL -lglut
+./hello
+```

--- a/native_linux/g++/opengl1.0_glut/triangle/readme.md
+++ b/native_linux/g++/opengl1.0_glut/triangle/readme.md
@@ -1,0 +1,6 @@
+## How to build
+
+```sh
+g++ -o hello hello.cpp -lGL -lglut
+./hello
+```

--- a/native_linux/g++/opengl1.1_glut/triangle/readme.md
+++ b/native_linux/g++/opengl1.1_glut/triangle/readme.md
@@ -1,0 +1,6 @@
+## How to build
+
+```sh
+g++ -o hello hello.cpp -lGL -lglut
+./hello
+```

--- a/native_linux/g++/opengl2.0_glut/triangle/readme.md
+++ b/native_linux/g++/opengl2.0_glut/triangle/readme.md
@@ -1,0 +1,6 @@
+## How to build
+
+```sh
+g++ -o hello hello.cpp -lGL -lglut
+./hello
+```

--- a/native_linux/g++/opengl3.3_glut/triangle/readme.md
+++ b/native_linux/g++/opengl3.3_glut/triangle/readme.md
@@ -1,0 +1,6 @@
+## How to build
+
+```sh
+g++ -o hello hello.cpp -lGL -lglut
+./hello
+```

--- a/native_linux/g++/opengl4.5_glut/triangle/readme.md
+++ b/native_linux/g++/opengl4.5_glut/triangle/readme.md
@@ -1,0 +1,6 @@
+## How to build
+
+```sh
+g++ -o hello hello.cpp -lGL -lglut
+./hello
+```


### PR DESCRIPTION
## Summary

Adds `readme.md` files that were accidentally omitted from the Linux OpenGL+GLUT samples for `g++` and `clang++`.

## Missing Files Added

10 files across 2 compilers × 5 OpenGL versions:

| Compiler | OpenGL version | File added |
|----------|---------------|------------|
| g++ | 1.0, 1.1, 2.0, 3.3, 4.5 | `readme.md` |
| clang++ | 1.0, 1.1, 2.0, 3.3, 4.5 | `readme.md` |

## Content

Each `readme.md` documents how to build and run the sample:

```sh
g++ -o hello hello.cpp -lGL -lglut
./hello
```

```sh
clang++ -o hello hello.cpp -lGL -lglut
./hello
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>