### PR TITLE
Add MoonBit console Hello World sample on Linux

### DIFF
--- a/native_linux/moonbit/console/hello/build.sh
+++ b/native_linux/moonbit/console/hello/build.sh
@@ -1,0 +1,2 @@
+moon run cmd/main
+moon build --target native

--- a/native_linux/moonbit/console/hello/clean.sh
+++ b/native_linux/moonbit/console/hello/clean.sh
@@ -1,0 +1,1 @@
+rm -rf _build

--- a/native_linux/moonbit/console/hello/cmd/main/hello.mbt
+++ b/native_linux/moonbit/console/hello/cmd/main/hello.mbt
@@ -1,0 +1,1 @@
+fn main { println("Hello, MoonBit World!") }

--- a/native_linux/moonbit/console/hello/cmd/main/moon.pkg
+++ b/native_linux/moonbit/console/hello/cmd/main/moon.pkg
@@ -1,0 +1,6 @@
+import {
+}
+
+options(
+	"is-main": true,
+)

--- a/native_linux/moonbit/console/hello/moon.mod.json
+++ b/native_linux/moonbit/console/hello/moon.mod.json
@@ -1,0 +1,5 @@
+{
+  "name": "cx20/hello-moonbit-native-linux-console",
+  "version": "0.1.0",
+  "preferred-target": "native"
+}

--- a/native_linux/moonbit/console/hello/moon.pkg
+++ b/native_linux/moonbit/console/hello/moon.pkg
@@ -1,0 +1,1 @@
+// Root package marker.

--- a/native_linux/moonbit/console/hello/readme.md
+++ b/native_linux/moonbit/console/hello/readme.md
@@ -1,0 +1,22 @@
+compile:
+```
+$ moon run cmd/main
+$ moon build --target native
+```
+Result:
+```
++--------------------------------------------------+
+|user@HOSTNAME:~/moonbit/console/hello    [_][~][X]|
++--------------------------------------------------+
+|$ moon run cmd/main                               |
+|Hello, MoonBit World!                            |
+|                                                  |
+|                                                  |
+|                                                  |
+|                                                  |
+|                                                  |
+|                                                  |
+|                                                  |
+|                                                  |
++--------------------------------------------------+
+```

--- a/native_linux/moonbit/console/hello/run.sh
+++ b/native_linux/moonbit/console/hello/run.sh
@@ -1,0 +1,1 @@
+moon run cmd/main


### PR DESCRIPTION
## Summary
- Add MoonBit console Hello World sample for Linux under `native_linux/moonbit/console/hello/`
- Verified with WSL (Ubuntu 24.04): both `moon run cmd/main` and `moon build --target native` work correctly
- Follows the same structure as the Windows version (`native_win/moonbit/console/hello/`) with `.sh` scripts instead of `.bat`

## Test plan
- [ ] Run `moon run cmd/main` in WSL (Ubuntu 24.04) → outputs `Hello, MoonBit World!`
- [ ] Run `moon build --target native` in WSL (Ubuntu 24.04) → build succeeds
- [ ] Run the compiled native binary directly → outputs `Hello, MoonBit World!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)