### PR TITLE
Update Chrome Canary version to 152 in Test Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Note: In this table, `Cocoa GUI` means native macOS AppKit/Cocoa window-based sa
 |Browser      |Version|Remarks|
 |:-----------:|:-----:|:-----:|
 |Chrome Stable|149    |       |
-|Chrome Canary|151    |       |
+|Chrome Canary|152    |       |
 
 |Language   |Version|Remarks                                         |
 |:---------:|:-----:|:----------------------------------------------:|


### PR DESCRIPTION
## Summary
- Update the Chrome Canary version from 151 to 152 in the Test Environment table of README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)