### PR TITLE
Update Chrome Stable version to 150 in Test Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Note: In this table, `Cocoa GUI` means native macOS AppKit/Cocoa window-based sa
 
 |Browser      |Version|Remarks|
 |:-----------:|:-----:|:-----:|
-|Chrome Stable|149    |       |
+|Chrome Stable|150    |       |
 |Chrome Canary|152    |       |
 
 |Language   |Version|Remarks                                         |


### PR DESCRIPTION
Update the Chrome Stable version in the Test Environment table of README.md from 149 to 150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)