### PR TITLE
Update Chrome Canary version to 153 in Test Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Note: In this table, `Cocoa GUI` means native macOS AppKit/Cocoa window-based sa
 |Browser      |Version|Remarks|
 |:-----------:|:-----:|:-----:|
 |Chrome Stable|150    |       |
-|Chrome Canary|152    |       |
+|Chrome Canary|153    |       |
 
 |Language   |Version|Remarks                                         |
 |:---------:|:-----:|:----------------------------------------------:|


### PR DESCRIPTION
## Summary
- Update the Chrome Canary version from 152 to 153 in the Test Environment table of README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)